### PR TITLE
Add support to full path of OU within AD infrastructure + option to specify OU to analyze GPOs in (with or without recurse)

### DIFF
--- a/grouper.psm1
+++ b/grouper.psm1
@@ -1736,9 +1736,12 @@ Function Invoke-AuditGPO {
     }
 
     #check if it's linked somewhere
-    $gpopath = $xmlgpo.LinksTo.SOMName
+    #get OU name
+    $gponame = $xmlgpo.LinksTo.SOMName
+    #get OU path
+    $gpopath = $xmlgpo.LinksTo.SOMPath
     #and if it's not, increment our count of GPOs that don't do anything
-    if ((-Not $gpopath) -And (!$Global:showdisabled)) {
+    if ((-Not $gponame) -And (!$Global:showdisabled)) {
         $Global:unlinkedPols += 1
         return $null
     }
@@ -1795,7 +1798,8 @@ Function Invoke-AuditGPO {
     $headers += {'Policy created on: {0:G}' -f ([DateTime]$xmlgpo.CreatedTime)}
     $headers += {'Policy last modified: {0:G}' -f ([DateTime]$xmlgpo.ModifiedTime)}
     $headers += {'Policy owner: {0}' -f $owner}
-    $headers += {'Linked OU: {0}' -f $gpopath}
+    $headers += {'Linked OU name: {0}' -f $gponame}
+    $headers += {'Linked OU full path: {0}' -f $gpopath}
     $headers += {'Link enabled: {0}' -f $gpoisenabled}
     $headers += {'==============================================================='}
 


### PR DESCRIPTION
Hi,

thank you very much for this tool that gives a good basis while analyzing GPOs!

This PR adds the display of the full path of an OU while treating GPOs. Indeed different OUs may have the same name while being located in another location within the AD infrastructure. The variable name was also changed to follow the naming "SOMName" and "SOMPath" of the Get-GPORerport produced XML.

Furthermore the 2nd commit adds the option to specify an OU to analyze GPOs in (with or without recurse). This can be interesting while trying to debug specific GPOs in OUs (like parameter override or inheritance blocked) ;-).

Please note that I'm a not (yet) a PowerShell guy so feel free to give me some feedback regarding implementation :-).

This last feature has been tested only with the "WithFile" option, thus Domain and WithoutFile is not included in this PR.

Cheers!